### PR TITLE
Escape paths

### DIFF
--- a/Dropbox/API.php
+++ b/Dropbox/API.php
@@ -336,6 +336,8 @@ class API
 	private function normalisePath($path)
 	{
 		$path = preg_replace('#/+#', '/', trim($path, '/'));
+		$path = rawurlencode($path);
+		$path = str_replace('%2F', '/', $path);
 		return $path;
 	}
 }


### PR DESCRIPTION
Escape paths (otherwise the Dropbox API throws an 'Invalid signature' error)
