### PR TITLE
Added server port optional argument to Dropbox\OAuth\Storage\PDO connect()

### DIFF
--- a/Dropbox/OAuth/Storage/PDO.php
+++ b/Dropbox/OAuth/Storage/PDO.php
@@ -63,11 +63,12 @@ class PDO extends Session
      * @param string $db Database to connect to
      * @param string $user Database username
      * @param string $pass Database user password
+     * @param int $port Database server port (default 3306)
      * @return void
      */
-    public function connect($host, $db, $user, $pass)
+    public function connect($host, $db, $user, $pass, $port = 3306)
     {
-        $dsn = 'mysql:host=' . $host . ';dbname=' . $db;
+        $dsn = 'mysql:host=' . $host . ';port=' . $port . ';dbname=' . $db;
         $this->pdo = new \PDO($dsn, $user, $pass, $this->options);
     }
     

--- a/examples/bootstrap.php
+++ b/examples/bootstrap.php
@@ -43,6 +43,9 @@ $storage = new \Dropbox\OAuth\Storage\Session($encrypter);
 //$userID = 1; // User ID assigned by your auth system
 //$storage = new \Dropbox\OAuth\Storage\PDO($encrypter, $userID);
 //$storage->connect('host', 'db', 'username', 'password');
+//
+// Optionally, a port number can be provided. By default this is 3306.
+//$storage->connect('host', 'db', 'username', 'password', 6600);
 
 $OAuth = new \Dropbox\OAuth\Consumer\Curl($key, $secret, $storage, $callback);
 $dropbox = new \Dropbox\API($OAuth);


### PR DESCRIPTION
I've added an optional argument to connect() in the PDO class to allow different ports to be used.

It will default to 3306 and existing an code base using this function will not be affected.

I also updated the bootstrap.php example file to reflect these changes.
