### PR TITLE
Upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # Composer
 composer.lock
 vendor/
+
+# Apple
+.DS_Store

--- a/Dropbox/API.php
+++ b/Dropbox/API.php
@@ -190,10 +190,10 @@ class API
                     // Close the file handle for this chunk
                     fclose($chunkHandle);
                 }
-                
+
                 // Complete the chunked upload
                 $filename = (is_string($filename)) ? $filename : basename($file);
-                $call = 'commit_chunked_upload/' . $this->root . '/' . $this->encodePath($path . $filename);
+                $call = 'commit_chunked_upload/' . $this->root . '/' . $this->encodePath(rtrim($path, '/') . '/' . $filename);
                 $params = array('overwrite' => (int) $overwrite, 'upload_id' => $uploadID);
                 $response = $this->fetch('POST', self::CONTENT_URL, $call, $params);
                 return $response;

--- a/Dropbox/API.php
+++ b/Dropbox/API.php
@@ -148,9 +148,9 @@ class API
     {
         if (file_exists($file)) {
             if ($handle = @fopen($file, 'r')) {
-            	// Seek to the correct position on the file pointer
-				fseek($handle, $offset);
-				
+                // Seek to the correct position on the file pointer
+                fseek($handle, $offset);
+
                 // Read from the file handle until EOF, uploading each chunk
                 while ($data = fread($handle, $this->chunkSize)) {
                     // Open a temporary file handle and write a chunk of data to it
@@ -183,10 +183,10 @@ class API
                     }
                     
                     // Set the data offset
-                	if (isset($response['body']->offset)) {
-						$offset = $response['body']->offset;
-					}
-                    
+                    if (isset($response['body']->offset)) {
+                        $offset = $response['body']->offset;
+                    }
+
                     // Close the file handle for this chunk
                     fclose($chunkHandle);
                 }

--- a/Dropbox/OAuth/Consumer/Curl.php
+++ b/Dropbox/OAuth/Consumer/Curl.php
@@ -97,6 +97,11 @@ class Curl extends ConsumerAbstract
         
         // Execute and parse the response
         $response = curl_exec($handle);
+
+        //Check if a curl error has occured
+        if ($response === false)
+            throw new \Dropbox\Exception("Error Processing Request: " . curl_error($handle));
+
         curl_close($handle);
         
         // Parse the response if it is a string


### PR DESCRIPTION
Gday Ben,

Thanks heaps for writing this fantastic API! I have been using in my WordPress plugin and it has been working great. It turnes out it can work with PHP 5.2.16 or higher so I have back ported my version and simplified it a bit for better reuse.

Anyways I thought I would contribute some of my tweaks back upstream. 

**1. Ignore DS_Store on OSX and convert tabs to four spaces where spacing was off.**

They are both a tad annoying :-)

**2. Ensure the path has a trailing slash when uploading chunked uploads.**

Without it the file will be uploaded with a concatenated folder and file name.

**3. Raise an exception if a cURL error occurs**

The API raises Dropbox errors but not curl errors. I found this out the hard way on a flight the other day. 

I hope this helps!

Cheers,
Mikey
