### PR TITLE
Update ConsumerAbstract.php for new HTTP response code

### DIFF
--- a/Dropbox/OAuth/Consumer/ConsumerAbstract.php
+++ b/Dropbox/OAuth/Consumer/ConsumerAbstract.php
@@ -51,6 +51,9 @@ abstract class ConsumerAbstract
             } catch(\Dropbox\Exception $e) {
                 $this->getRequestToken();
                 $this->authorise();
+            } catch(\Dropbox\BadRequestException $e) {
+                $this->getRequestToken();
+                $this->authorise();
             }
         }
     }


### PR DESCRIPTION
As of today, Dropbox is sending a 400 error code in response to the getAccessToken() call that the authenticate() method makes, which was causing the 3-legged flow to abort, as the code wasn't catch-ing that. This amend fixes that and restores functionality.
