### PR TITLE
Fix bug that caused plugin to stop working in php 5.6

### DIFF
--- a/Dropbox/OAuth/Consumer/Curl.php
+++ b/Dropbox/OAuth/Consumer/Curl.php
@@ -74,6 +74,14 @@ class Curl extends ConsumerAbstract
     {
         // Get the signed request URL
         $request = $this->getSignedRequest($method, $url, $call, $additional);
+        
+        if (function_exists('curl_file_create')) {
+            foreach ($request['postfields'] as $name => &$value) {
+                if (preg_match('/^@(?<file>.+);filename=(?<filename>.+)$/', $value, $matches)) {
+                    $value = curl_file_create($matches['file'], 'application/octet-stream', $matches['filename']);
+                }
+            }
+        }
 
         // Initialise and execute a cURL request
         $handle = curl_init($request['url']);


### PR DESCRIPTION
I was running into [this issue too](https://wordpress.org/support/topic/wordpress-backup-to-dropbox-wpb2d-), and didn't feel like downgrading my php version.

All of this code is borrowed from https://github.com/xgin/Dropbox/commit/1978b382f335df71a414b34eb81e0da198fd4157 

It seems to work in my tests, although you might want to just resync the whole thing with the library you cloned it from instead to get any other necessary fixes.
